### PR TITLE
Fix pending emoji

### DIFF
--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -43,7 +43,7 @@ const emojis = [
   { id: "1059647332498542682", name: "BronzeII" },
   { id: "1059647333916233778", name: "BronzeIII" },
   { id: "1078545170133417985", name: "Grandmaster" },
-  { id: "1133094737222582533", name: "None" },
+  { id: "1133094737222582533", name: "Pending" },
 ];
 
 function uniqueId(id: string, name: string) {


### PR DESCRIPTION
We have special logic for the no matches case (showing "these connect codes have no results yet" or similar)

This should handle the emoji shown when there is 1-4 games